### PR TITLE
Fixed navigation on create profile page and logout

### DIFF
--- a/taletime/lib/listener/screens/detailed_playlist_page.dart
+++ b/taletime/lib/listener/screens/detailed_playlist_page.dart
@@ -19,117 +19,121 @@ class DetailedPlaylistPage extends StatefulWidget {
 }
 
 class _DetailedPlaylistPageState extends State<DetailedPlaylistPage> {
-
-
   @override
   Widget build(BuildContext context) {
     return StreamBuilder(
-      stream: Provider.of<ProfileState>(context).playlistsRef!.doc(widget.playlistId).snapshots(),
-      builder: (context, playlistSnap) {
-        var playlist = playlistSnap.data?.data();
+        stream: Provider.of<ProfileState>(context)
+            .playlistsRef!
+            .doc(widget.playlistId)
+            .snapshots(),
+        builder: (context, playlistSnap) {
+          var playlist = playlistSnap.data?.data();
 
-        if (playlist == null) {
-          return const Center(child: CircularProgressIndicator(),);
-        }
-        
-        return Scaffold(
-          appBar: AppBar(
-            title: Text(playlist.title ?? AppLocalizations.of(context)!.noTitle,
-                style: const TextStyle(fontSize: 24, color: Colors.white)),
-            actions: [
-              PopupMenuButton(
-                offset: const Offset(0, 40),
-                icon: const Icon(Icons.more_vert),
-                itemBuilder: (context) => [
-                  PopupMenuItem(
-                    onTap: () {
-                      Navigator.push(
-                        context,
-                        MaterialPageRoute(
-                          builder: (context) => EditPlaylistPage(
-                            playlist: playlist,
-                          ),
-                        ),
-                      );
-                    },
-                    value: AppLocalizations.of(context)!.edit,
-                    child: Text(AppLocalizations.of(context)!.edit),
-                  ),
-                  PopupMenuItem(
-                    onTap: () {
-                      Provider.of<ProfileState>(context, listen: false)
-                          .playlistsRef
-                          ?.doc(playlist.id)
-                          .delete();
-                      Navigator.pop(context);
-                    },
-                    value: AppLocalizations.of(context)!.delete,
-                    child: Text(AppLocalizations.of(context)!.delete),
-                  ),
-                ],
-              ),
-            ],
-          ),
-          body: Padding(
-            padding: const EdgeInsets.all(8.0),
-            child: Column(
-              mainAxisAlignment: MainAxisAlignment.start,
-              crossAxisAlignment: CrossAxisAlignment.start,
-              children: [
-                Text(
-                  playlist.description ??
-                      AppLocalizations.of(context)!.noDescriptionAvailable,
-                  textAlign: TextAlign.left,
-                  softWrap: true,
-                  style: const TextStyle(fontSize: 16, color: Colors.black45),
-                ),
-                const SizedBox(width: 8.0),
-                Text(AppLocalizations.of(context)!.stories,
-                    textAlign: TextAlign.center,
-                    style: const TextStyle(fontSize: 24, color: Colors.black)),
-                Expanded(
-                  child: ListView.builder(
+          if (playlist == null) {
+            return const Center(
+              child: CircularProgressIndicator(),
+            );
+          }
 
-                    itemCount:
-                        playlist.stories != null ? playlist.stories!.length : 0,
-                    itemBuilder: (context, index) {
-                      return Padding(
-                        padding: const EdgeInsets.all(8.0),
-                        child: StoryListItem(
-                          story: playlist.stories![index],
-                          buttons: [
-                            StoryActionButton(
-                              icon: Icons.play_arrow,
-                              onTap: () {
-                                if (playlist.stories == null) return;
-                                if (audioHandler.customState.value
-                                    is CustomPlayerState) {
-                                  var state = audioHandler.customState.value
-                                      as CustomPlayerState;
-                                  state.setPlaylist(playlist.stories!);
-                                  state.currentStoryPlayed = index;
-                                }
-                                StoryPlayer.playStory(
-                                    context, playlist.stories![index]);
-
-                                Navigator.of(context).push(
-                                  MaterialPageRoute(
-                                    builder: (context) => const StoryPlayer(),
-                                  ),
-                                );
-                              },
+          return Scaffold(
+            appBar: AppBar(
+              title: Text(
+                  playlist.title ?? AppLocalizations.of(context)!.noTitle,
+                  style: const TextStyle(fontSize: 24, color: Colors.white)),
+              actions: [
+                PopupMenuButton(
+                  offset: const Offset(0, 40),
+                  icon: const Icon(Icons.more_vert),
+                  itemBuilder: (context) => [
+                    PopupMenuItem(
+                      onTap: () {
+                        Navigator.push(
+                          context,
+                          MaterialPageRoute(
+                            builder: (context) => EditPlaylistPage(
+                              playlist: playlist,
                             ),
-                          ],
-                        ),
-                      );
-                    },
-                  ),
+                          ),
+                        );
+                      },
+                      value: AppLocalizations.of(context)!.edit,
+                      child: Text(AppLocalizations.of(context)!.edit),
+                    ),
+                    PopupMenuItem(
+                      onTap: () {
+                        Provider.of<ProfileState>(context, listen: false)
+                            .playlistsRef
+                            ?.doc(playlist.id)
+                            .delete();
+                        Navigator.pop(context);
+                      },
+                      value: AppLocalizations.of(context)!.delete,
+                      child: Text(AppLocalizations.of(context)!.delete),
+                    ),
+                  ],
                 ),
               ],
             ),
-          ),
-        );
-      }
-    );
+            body: Padding(
+              padding: const EdgeInsets.all(8.0),
+              child: Column(
+                mainAxisAlignment: MainAxisAlignment.start,
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Text(
+                    playlist.description ??
+                        AppLocalizations.of(context)!.noDescriptionAvailable,
+                    textAlign: TextAlign.left,
+                    softWrap: true,
+                    style: const TextStyle(fontSize: 16, color: Colors.black45),
+                  ),
+                  const SizedBox(width: 8.0),
+                  Text(AppLocalizations.of(context)!.stories,
+                      textAlign: TextAlign.center,
+                      style:
+                          const TextStyle(fontSize: 24, color: Colors.black)),
+                  Expanded(
+                    child: ListView.builder(
+                      itemCount: playlist.stories != null
+                          ? playlist.stories!.length
+                          : 0,
+                      itemBuilder: (context, index) {
+                        return Padding(
+                          padding: const EdgeInsets.all(8.0),
+                          child: StoryListItem(
+                            story: playlist.stories![index],
+                            buttons: [
+                              StoryActionButton(
+                                icon: Icons.play_arrow,
+                                onTap: () {
+                                  if (playlist.stories == null) return;
+                                  if (audioHandler.customState.value
+                                      is CustomPlayerState) {
+                                    var state = audioHandler.customState.value
+                                        as CustomPlayerState;
+                                    state.setPlaylist(playlist.stories!);
+                                    state.currentStoryPlayed = index;
+                                  }
+                                  StoryPlayer.playStory(
+                                      context, playlist.stories![index]);
+
+                                  Navigator.of(context).push(
+                                    MaterialPageRoute(
+                                      builder: (context) => const StoryPlayer(),
+                                    ),
+                                  );
+                                },
+                              ),
+                            ],
+                          ),
+                        );
+                      },
+                    ),
+                  ),
+                ],
+              ),
+            ),
+          );
+        });
   }
 }

--- a/taletime/lib/listener/utils/navbar_widget_listener.dart
+++ b/taletime/lib/listener/utils/navbar_widget_listener.dart
@@ -5,7 +5,6 @@ import "package:taletime/common/models/added_story.dart";
 import "package:taletime/common/models/story.dart";
 import "package:taletime/internationalization/localizations_ext.dart";
 
-import "../../settings/settings.dart";
 import "../../state/profile_state.dart";
 import "../screens/add_story_page.dart";
 import "../screens/favorites_page.dart";
@@ -79,8 +78,7 @@ class _NavBarListenerState extends State<NavBarListener> {
           ),
           navBarItems(
               Icons.favorite_sharp, AppLocalizations.of(context)!.favorites),
-          navBarItems(
-              Icons.add, AppLocalizations.of(context)!.addStory),
+          navBarItems(Icons.add, AppLocalizations.of(context)!.addStory),
           navBarItems(Icons.playlist_add_circle,
               AppLocalizations.of(context)!.playlists),
         ],

--- a/taletime/lib/listener/utils/playlist_list.dart
+++ b/taletime/lib/listener/utils/playlist_list.dart
@@ -66,7 +66,8 @@ class PlaylistList extends StatelessWidget {
                                 ),
                                 Text(
                                   playlist.description ??
-                                      AppLocalizations.of(context)!.noDescriptionAvailable,
+                                      AppLocalizations.of(context)!
+                                          .noDescriptionAvailable,
                                   softWrap: true,
                                   overflow: TextOverflow.fade,
                                   style: const TextStyle(

--- a/taletime/lib/login and registration/utils/authentification_util.dart
+++ b/taletime/lib/login and registration/utils/authentification_util.dart
@@ -41,10 +41,14 @@ class AuthentificationUtil {
             content: Text(AppLocalizations.of(context)!.signInSuccesful),
             backgroundColor: kPrimaryColor);
         ScaffoldMessenger.of(context).showSnackBar(signinSuccesful);
-        Navigator.of(context).pushReplacement(MaterialPageRoute(
+        Navigator.of(context).pushAndRemoveUntil(
+          MaterialPageRoute(
             builder: (context) => ProfilesPage(
-                  redirectTo: redirectTo,
-                )));
+              redirectTo: redirectTo,
+            ),
+          ),
+          (route) => false,
+        );
       }
     } on FirebaseAuthException catch (e) {
       final SnackBar snackBar = ErrorUtil().showLoginError(e, context);
@@ -86,10 +90,14 @@ class AuthentificationUtil {
 
         addUserInfoToDB(auth.currentUser!.uid, userInfoMap);
 
-        Navigator.of(context).pushReplacement(MaterialPageRoute(
+        Navigator.of(context).pushAndRemoveUntil(
+          MaterialPageRoute(
             builder: (context) => ProfilesPage(
-                  redirectTo: redirectTo,
-                )));
+              redirectTo: redirectTo,
+            ),
+          ),
+          (route) => false,
+        );
       }
     } on FirebaseAuthException catch (e) {
       final SnackBar snackBar = ErrorUtil().showRegisterError(e, context);

--- a/taletime/lib/main.dart
+++ b/taletime/lib/main.dart
@@ -5,13 +5,12 @@ import "package:flutter/material.dart";
 import "package:flutter_localizations/flutter_localizations.dart";
 import "package:flutter_native_splash/flutter_native_splash.dart";
 import "package:flutter_web_plugins/url_strategy.dart";
-import "package:go_router/go_router.dart";
 import "package:provider/provider.dart";
 import "package:taletime/common%20utils/theme_provider.dart";
 import "package:taletime/internationalization/l10n.dart";
 import "package:taletime/internationalization/locale_provider.dart";
 import "package:taletime/login%20and%20registration/screens/welcome.dart";
-import 'package:taletime/player/services/audio_handler.dart';
+import "package:taletime/player/services/audio_handler.dart";
 import "package:taletime/profiles/screens/profiles_page.dart";
 import "package:taletime/share/screens/shared_story.dart";
 import "package:taletime/state/profile_state.dart";
@@ -92,21 +91,24 @@ class Providers extends StatelessWidget {
     final languageProvider = Provider.of<LocaleProvider>(context);
     final themeProvider = Provider.of<ThemeProvider>(context);
 
-    return MaterialApp.router(
-      routerConfig: GoRouter(
-        routes: [
-          GoRoute(
-            path: "/",
-            builder: (_, __) => HomePage(),
-            routes: [
-              GoRoute(
-                path: "shared",
-                builder: (_, __) => const SharedStory(),
-              ),
-            ],
-          ),
-        ],
-      ),
+    return MaterialApp(
+      routes: {
+        "/": (_) => HomePage(),
+        "/shared": (_) => const SharedStory()
+      },
+      initialRoute: "/",
+      onGenerateRoute: (settings) {
+        var uri = Uri.parse(settings.name ?? "");
+
+        // Only react to shared route. Other routes have no matching screen.
+        if (uri.path == "/shared") {
+          return MaterialPageRoute(builder: (_) => SharedStory(
+            storyId: uri.queryParameters["storyId"],
+          ));
+        }
+
+        return null;
+      },
       debugShowCheckedModeBanner: false,
       themeMode: themeProvider.themeMode,
       theme: MyThemes.lightTheme,

--- a/taletime/lib/main.dart
+++ b/taletime/lib/main.dart
@@ -92,19 +92,17 @@ class Providers extends StatelessWidget {
     final themeProvider = Provider.of<ThemeProvider>(context);
 
     return MaterialApp(
-      routes: {
-        "/": (_) => HomePage(),
-        "/shared": (_) => const SharedStory()
-      },
+      routes: {"/": (_) => HomePage(), "/shared": (_) => const SharedStory()},
       initialRoute: "/",
       onGenerateRoute: (settings) {
         var uri = Uri.parse(settings.name ?? "");
 
         // Only react to shared route. Other routes have no matching screen.
         if (uri.path == "/shared") {
-          return MaterialPageRoute(builder: (_) => SharedStory(
-            storyId: uri.queryParameters["storyId"],
-          ));
+          return MaterialPageRoute(
+              builder: (_) => SharedStory(
+                    storyId: uri.queryParameters["storyId"],
+                  ));
         }
 
         return null;

--- a/taletime/lib/profiles/screens/profiles_page.dart
+++ b/taletime/lib/profiles/screens/profiles_page.dart
@@ -81,7 +81,7 @@ class _ProfilesPageState extends State<ProfilesPage> {
               padding: const EdgeInsets.only(right: 15.0),
               child: IconButton(
                 onPressed: () {
-                  Navigator.of(context).pushReplacement(MaterialPageRoute(
+                  Navigator.of(context).push(MaterialPageRoute(
                       builder: (context) => CreateEditProfile(
                             profile: defaultProfile,
                           )));

--- a/taletime/lib/profiles/utils/create_edit_profile.dart
+++ b/taletime/lib/profiles/utils/create_edit_profile.dart
@@ -11,7 +11,6 @@ import "../../common utils/theme_provider.dart";
 import "../../internationalization/locale_provider.dart";
 import "../../internationalization/localizations_ext.dart";
 import "../models/profile_model.dart";
-import "../screens/profiles_page.dart";
 
 class CreateEditProfile extends StatefulWidget {
   const CreateEditProfile({super.key, required this.profile});
@@ -78,16 +77,12 @@ class _CreateEditProfileState extends State<CreateEditProfile> {
         ? widget.profile.name
         : textEditingController.text;
 
-
     DocumentReference<Profile>? profileRef;
 
     if (widget.profile.id != "") {
-      profileRef = Provider
-          .of<UserState>(context)
-          .profilesRef
-          ?.doc(widget.profile.id);
+      profileRef =
+          Provider.of<UserState>(context).profilesRef?.doc(widget.profile.id);
     }
-
 
     return Scaffold(
       appBar: AppBar(
@@ -219,7 +214,8 @@ class _CreateEditProfileState extends State<CreateEditProfile> {
                             Navigator.of(context).pop();
                           } else {
                             ProfileService.addProfile(
-                                Provider.of<UserState>(context, listen: false).profilesRef!,
+                                Provider.of<UserState>(context, listen: false)
+                                    .profilesRef!,
                                 image,
                                 name,
                                 title,

--- a/taletime/lib/profiles/utils/create_edit_profile.dart
+++ b/taletime/lib/profiles/utils/create_edit_profile.dart
@@ -225,11 +225,7 @@ class _CreateEditProfileState extends State<CreateEditProfile> {
                                 title,
                                 languageProvider.locale.toString(),
                                 !themeProvider.isDarkMode);
-                            Navigator.push(
-                                context,
-                                MaterialPageRoute(
-                                    builder: (context) =>
-                                        const ProfilesPage()));
+                            Navigator.of(context).pop();
                           }
                         },
                         child: Text(

--- a/taletime/lib/profiles/utils/create_edit_profile.dart
+++ b/taletime/lib/profiles/utils/create_edit_profile.dart
@@ -78,8 +78,16 @@ class _CreateEditProfileState extends State<CreateEditProfile> {
         ? widget.profile.name
         : textEditingController.text;
 
-    DocumentReference<Profile>? profileRef =
-        Provider.of<UserState>(context).profilesRef?.doc(widget.profile.id);
+
+    DocumentReference<Profile>? profileRef;
+
+    if (widget.profile.id != "") {
+      profileRef = Provider
+          .of<UserState>(context)
+          .profilesRef
+          ?.doc(widget.profile.id);
+    }
+
 
     return Scaffold(
       appBar: AppBar(
@@ -211,7 +219,7 @@ class _CreateEditProfileState extends State<CreateEditProfile> {
                             Navigator.of(context).pop();
                           } else {
                             ProfileService.addProfile(
-                                Provider.of<UserState>(context).profilesRef!,
+                                Provider.of<UserState>(context, listen: false).profilesRef!,
                                 image,
                                 name,
                                 title,

--- a/taletime/lib/share/screens/shared_story.dart
+++ b/taletime/lib/share/screens/shared_story.dart
@@ -2,7 +2,6 @@ import "dart:math";
 
 import "package:cloud_firestore/cloud_firestore.dart";
 import "package:flutter/material.dart";
-import "package:go_router/go_router.dart";
 import "package:provider/provider.dart";
 import "package:taletime/common%20utils/constants.dart";
 import "package:taletime/common/models/story.dart";
@@ -15,39 +14,34 @@ import "package:taletime/share/screens/add_shared_story.dart";
 import "package:taletime/state/profile_state.dart";
 import "package:taletime/state/user_state.dart";
 
-class SharedStoryArguments {
-  SharedStoryArguments(this.storyId);
+class SharedStory extends StatefulWidget {
+  const SharedStory({super.key, this.storyId});
 
   final String? storyId;
-}
-
-class SharedStory extends StatefulWidget {
-  const SharedStory({super.key});
 
   @override
   State<StatefulWidget> createState() => SharedStoryState();
 }
 
 class SharedStoryState extends State<SharedStory> {
-  String? _storyId;
+
   DocumentReference<Story>? _storyRef;
 
   @override
   void initState() {
     super.initState();
 
-    WidgetsBinding.instance.addPostFrameCallback((_) async {
-      setState(() {
-        _storyId = GoRouterState.of(context).uri.queryParameters["storyId"];
+    if (widget.storyId == null) {
+      return;
+    }
 
-        _storyRef = FirebaseFirestore.instance
-            .doc("allStories/$_storyId")
+    _storyRef = FirebaseFirestore.instance
+            .doc("allStories/${widget.storyId}")
             .withConverter(
               fromFirestore: (snap, _) => Story.fromDocumentSnapshot(snap),
               toFirestore: (snap, _) => snap.toFirebase(),
             );
-      });
-    });
+
   }
 
   Widget _buildStoryMetadata(BuildContext context, Story? story) {

--- a/taletime/lib/share/screens/shared_story.dart
+++ b/taletime/lib/share/screens/shared_story.dart
@@ -24,7 +24,6 @@ class SharedStory extends StatefulWidget {
 }
 
 class SharedStoryState extends State<SharedStory> {
-
   DocumentReference<Story>? _storyRef;
 
   @override
@@ -36,12 +35,11 @@ class SharedStoryState extends State<SharedStory> {
     }
 
     _storyRef = FirebaseFirestore.instance
-            .doc("allStories/${widget.storyId}")
-            .withConverter(
-              fromFirestore: (snap, _) => Story.fromDocumentSnapshot(snap),
-              toFirestore: (snap, _) => snap.toFirebase(),
-            );
-
+        .doc("allStories/${widget.storyId}")
+        .withConverter(
+          fromFirestore: (snap, _) => Story.fromDocumentSnapshot(snap),
+          toFirestore: (snap, _) => snap.toFirebase(),
+        );
   }
 
   Widget _buildStoryMetadata(BuildContext context, Story? story) {

--- a/taletime/pubspec.lock
+++ b/taletime/pubspec.lock
@@ -629,14 +629,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.1.2"
-  go_router:
-    dependency: "direct main"
-    description:
-      name: go_router
-      sha256: abec47eb8c8c36ebf41d0a4c64dbbe7f956e39a012b3aafc530e951bdc12fe3f
-      url: "https://pub.dev"
-    source: hosted
-    version: "14.1.4"
   graphs:
     dependency: transitive
     description:
@@ -1491,5 +1483,5 @@ packages:
     source: hosted
     version: "3.1.2"
 sdks:
-  dart: ">=3.3.0 <4.0.0"
+  dart: ">=3.4.0 <4.0.0"
   flutter: ">=3.19.0"

--- a/taletime/pubspec.yaml
+++ b/taletime/pubspec.yaml
@@ -61,7 +61,6 @@ dependencies:
   flutter_launcher_icons: ^0.13.1
   audio_service: ^0.18.13
   just_audio: ^0.9.38
-  go_router: ^14.1.4
 
 dependency_overrides:
   # FIXME remove this version override when possible


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

There was a bug in debug builds when clicking the add profile button. The create profile page could not load and no profiles could be created. This could be traced down to passing an empty string as profile id. This PR solved this issue by not loading a document reference when there is no ID present.

There was also a problem with routing. After logging out, the app crashed and could not navigate back to welcome page. As well as fixing this bug, there were removed some other routing issues and inconsistencies.

### Linked Issues

#266 

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

The bug around the create profile screen was unnoticed for a longer time, because it only occurred in debug mode and only if there was no release mode running before. Apparently, the release mode does not complain about the empty path in the document reference and stores a state in the app's data that lets the bug go away in debug mode as well. Only after deleting application data, the bug was present again. 

The logout bug could be traced down to clearing the navigation stack. This operation was not compatible with `go_router` library, that was introduced when improved story sharing was implemented. This library could be replaced by plain flutter navigation and routing.